### PR TITLE
Simple GH actions config to make the workflow show up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+# Minimal workflow to get in the GitHub system so can implement CI later
+
+name: CI
+
+on:
+  pull_request:
+    branches: [ $default-branch ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2


### PR DESCRIPTION
The workflow won't show up in the UI until it's merged to master, so this PR makes a very simple workflow that just checks out the repo to make this happen.
